### PR TITLE
Add options to the log-in attempt

### DIFF
--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -465,6 +465,9 @@ export class AccountsServer extends AccountsCommon {
     if (user) {
       attempt.user = user;
     }
+    if (result.options) {
+      attempt.options = result.options;
+    }
 
     // _validateLogin may mutate `attempt` by adding an error and changing allowed
     // to false, but that's the only change it can make (and the user's callbacks
@@ -1842,4 +1845,3 @@ const generateCasePermutationsForString = string => {
   }
   return permutations;
 }
-

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'A user account system',
-  version: '2.2.5',
+  version: '2.2.5-2',
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
Add any options added to the log-in `result` to the `attempt` built by `Accounts._attemptLogin`.