### PR TITLE
Update @meteor/accounts-base version to fix semver

### DIFF
--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'A user account system',
-  version: '2.2.5-2',
+  version: '2.2.6-2',
 });
 
 Package.onUse(api => {


### PR DESCRIPTION
```
2.2.5-2 < 2.2.5 < 2.2.6-2 < 2.2.6
```

Because of this, we need to change this from `2.2.5-2` to `2.2.6-2` so that `^2.2.5` will pick it up.