### PR TITLE
Fix ts definitions

### DIFF
--- a/packages/accounts-base/accounts-base.d.ts
+++ b/packages/accounts-base/accounts-base.d.ts
@@ -1,5 +1,5 @@
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
+import { Meteor as BaseMeteor } from 'meteor/meteor';
 
 export interface URLS {
   resetPassword: (token: string) => string;
@@ -8,10 +8,19 @@ export interface URLS {
 }
 
 export interface EmailFields {
-  from?: ((user: Meteor.User) => string) | undefined;
-  subject?: ((user: Meteor.User) => string) | undefined;
-  text?: ((user: Meteor.User, url: string) => string) | undefined;
-  html?: ((user: Meteor.User, url: string) => string) | undefined;
+  from?: ((user: BaseMeteor.User) => string) | undefined;
+  subject?: ((user: BaseMeteor.User) => string) | undefined;
+  text?: ((user: BaseMeteor.User, url: string) => string) | undefined;
+  html?: ((user: BaseMeteor.User, url: string) => string) | undefined;
+}
+
+export namespace Meteor {
+  function user(options?: {
+    fields?: Mongo.FieldSpecifier | undefined;
+  }): BaseMeteor.User | null;
+
+  function userId(): string | null;
+  var users: Mongo.Collection<BaseMeteor.User>;
 }
 
 export namespace Accounts {
@@ -19,7 +28,7 @@ export namespace Accounts {
 
   function user(options?: {
     fields?: Mongo.FieldSpecifier | undefined;
-  }): Meteor.User | null;
+  }): BaseMeteor.User | null;
 
   function userId(): string | null;
 
@@ -30,7 +39,7 @@ export namespace Accounts {
       password?: string | undefined;
       profile?: Object | undefined;
     },
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): string;
 
   function config(options: {
@@ -66,23 +75,23 @@ export namespace Accounts {
   function changePassword(
     oldPassword: string,
     newPassword: string,
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   function forgotPassword(
     options: { email?: string | undefined },
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   function resetPassword(
     token: string,
     newPassword: string,
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   function verifyEmail(
     token: string,
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   function onEmailVerificationLink(callback: Function): void;
@@ -96,11 +105,11 @@ export namespace Accounts {
   function loggingOut(): boolean;
 
   function logout(
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   function logoutOtherClients(
-    callback?: (error?: Error | Meteor.Error | Meteor.TypedError) => void
+    callback?: (error?: Error | BaseMeteor.Error | BaseMeteor.TypedError) => void
   ): void;
 
   var ui: {
@@ -134,18 +143,18 @@ export namespace Accounts {
   function removeEmail(userId: string, email: string): void;
 
   function onCreateUser(
-    func: (options: { profile?: {} | undefined }, user: Meteor.User) => void
+    func: (options: { profile?: {} | undefined }, user: BaseMeteor.User) => void
   ): void;
 
   function findUserByEmail(
     email: string,
     options?: { fields?: Mongo.FieldSpecifier | undefined }
-  ): Meteor.User | null | undefined;
+  ): BaseMeteor.User | null | undefined;
 
   function findUserByUsername(
     username: string,
     options?: { fields?: Mongo.FieldSpecifier | undefined }
-  ): Meteor.User | null | undefined;
+  ): BaseMeteor.User | null | undefined;
 
   function sendEnrollmentEmail(
     userId: string,
@@ -191,9 +200,9 @@ export namespace Accounts {
   interface IValidateLoginAttemptCbOpts {
     type: string;
     allowed: boolean;
-    error: Meteor.Error;
-    user: Meteor.User;
-    connection: Meteor.Connection;
+    error: BaseMeteor.Error;
+    user: BaseMeteor.User;
+    connection: BaseMeteor.Connection;
     methodName: string;
     methodArguments: any[];
   }
@@ -206,8 +215,8 @@ export namespace Accounts {
 export namespace Accounts {
   function onLogout(
     func: (options: {
-      user: Meteor.User;
-      connection: Meteor.Connection;
+      user: BaseMeteor.User;
+      connection: BaseMeteor.Connection;
     }) => void
   ): void;
 }
@@ -245,7 +254,7 @@ export namespace Accounts {
    * optionally `tokenExpires`.
    *
    * This function takes care of:
-   * - Updating the Meteor.loggingIn() reactive data source
+   * - Updating the BaseMeteor.loggingIn() reactive data source
    * - Calling the method in 'wait' mode
    * - On success, saving the resume token to localStorage
    * - On success, calling Accounts.connection.setUserId()
@@ -300,7 +309,7 @@ export namespace Accounts {
    * `password.digest`).
    */
   function _checkPassword(
-    user: Meteor.User,
+    user: BaseMeteor.User,
     password: Password
   ): { userId: string; error?: any };
 }

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'A user account system',
-  version: '2.2.6-2',
+  version: '2.2.6-qualia.3',
 });
 
 Package.onUse(api => {

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'A user account system',
-  version: '2.2.6-qualia.3',
+  version: '2.2.6',
 });
 
 Package.onUse(api => {

--- a/packages/ddp/ddp.d.ts
+++ b/packages/ddp/ddp.d.ts
@@ -1,8 +1,11 @@
-import { Meteor } from 'meteor/meteor';
+import { Meteor as BaseMeteor } from 'meteor/meteor';
+import { EJSONable, EJSONableProperty } from 'meteor/ejson';
+
+export type global_Error = Error;
 
 export namespace DDP {
   interface DDPStatic {
-    subscribe(name: string, ...rest: any[]): Meteor.SubscriptionHandle;
+    subscribe(name: string, ...rest: any[]): BaseMeteor.SubscriptionHandle;
     call(method: string, ...parameters: any[]): any;
     apply(method: string, ...parameters: any[]): any;
     methods(IMeteorMethodsDictionary: any): any;
@@ -27,12 +30,80 @@ export namespace DDP {
   function connect(url: string): DDPStatic;
 }
 
+export namespace Meteor {
+
+  /** Method **/
+  interface MethodThisType {
+    /** Access inside a method invocation. Boolean value, true if this invocation is a stub. */
+    isSimulation: boolean;
+    /** The id of the user that made this method call, or `null` if no user was logged in. */
+    userId: string | null;
+    /**
+     * Access inside a method invocation. The connection that this method was received on. `null` if the method is not associated with a connection, eg. a server initiated method call. Calls
+     * to methods made from a server method which was in turn initiated from the client share the same `connection`. */
+    connection: BaseMeteor.Connection | null;
+    /**
+     * Set the logged in user.
+     * @param userId The value that should be returned by `userId` on this connection.
+     */
+    setUserId(userId: string | null): void;
+    /** Call inside a method invocation. Allow subsequent method from this client to begin running in a new fiber. */
+    unblock(): void;
+  }
+
+  /**
+   * Defines functions that can be invoked over the network by clients.
+   * @param methods Dictionary whose keys are method names and values are functions.
+   */
+  function methods(methods: {
+    [key: string]: (this: MethodThisType, ...args: any[]) => any;
+  }): void;
+
+  /**
+   * Invokes a method passing any number of arguments.
+   * @param name Name of method to invoke
+   * @param args Optional method arguments
+   */
+  function call(name: string, ...args: any[]): any;
+
+  function apply<
+    Result extends
+      | EJSONable
+      | EJSONable[]
+      | EJSONableProperty
+      | EJSONableProperty[]
+  >(
+    name: string,
+    args: ReadonlyArray<EJSONable | EJSONableProperty>,
+    options?: {
+      wait?: boolean | undefined;
+      onResultReceived?:
+        | ((
+            error: global_Error | BaseMeteor.Error | undefined,
+            result?: Result
+          ) => void)
+        | undefined;
+      /**
+       * (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
+       */
+      noRetry?: boolean | undefined;
+      returnStubValue?: boolean | undefined;
+      throwStubExceptions?: boolean | undefined;
+    },
+    asyncCallback?: (
+      error: global_Error | BaseMeteor.Error | undefined,
+      result?: Result
+    ) => void
+  ): any;
+  /** Method **/
+}
+
 export namespace DDPCommon {
   interface MethodInvocationOptions {
     userId: string | null;
     setUserId?: ((newUserId: string) => void) | undefined;
     isSimulation: boolean;
-    connection: Meteor.Connection;
+    connection: BaseMeteor.Connection;
     randomSeed: string;
   }
 
@@ -60,6 +131,16 @@ export namespace DDPCommon {
      * Access inside a method invocation. The [connection](#meteor_onconnection) that this method was received on. `null` if the method is not associated with a connection, eg. a server
      * initiated method call. Calls to methods made from a server method which was in turn initiated from the client share the same `connection`.
      */
-    connection: Meteor.Connection;
+    connection: BaseMeteor.Connection;
   }
+
+  /** Connection **/
+  function reconnect(): void;
+
+  function disconnect(): void;
+  /** Connection **/
+
+  /** Status **/
+  function status(): DDP.DDPStatus;
+  /** Status **/
 }

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data framework",
-  version: '1.4.1'
+  version: '1.4.2-qualia.1'
 });
 
 Package.onUse(function (api) {

--- a/packages/ddp/package.js
+++ b/packages/ddp/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Meteor's latency-compensated distributed data framework",
-  version: '1.4.2-qualia.1'
+  version: '1.4.2'
 });
 
 Package.onUse(function (api) {

--- a/packages/email/package.js
+++ b/packages/email/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Send email messages',
-  version: '2.2.2-1',
+  version: '2.2.3',
 });
 
 Npm.depends({

--- a/packages/inter-process-messaging/package.js
+++ b/packages/inter-process-messaging/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "inter-process-messaging",
-  version: "0.1.1",
+  version: "0.1.2",
   summary: "Support for sending messages from the build process to the server process",
   documentation: "README.md"
 });

--- a/packages/meteor/meteor.d.ts
+++ b/packages/meteor/meteor.d.ts
@@ -1,8 +1,3 @@
-import { Mongo } from 'meteor/mongo';
-import { EJSONable, EJSONableProperty } from 'meteor/ejson';
-import { Blaze } from 'meteor/blaze';
-import { DDP } from 'meteor/ddp';
-
 export type global_Error = Error;
 
 export namespace Meteor {
@@ -57,13 +52,6 @@ export namespace Meteor {
     profile?: UserProfile;
     services?: any;
   }
-
-  function user(options?: {
-    fields?: Mongo.FieldSpecifier | undefined;
-  }): User | null;
-
-  function userId(): string | null;
-  var users: Mongo.Collection<User>;
   /** User **/
 
   /** Error **/
@@ -118,71 +106,6 @@ export namespace Meteor {
     errorType: string;
   }
   /** Error **/
-
-  /** Method **/
-  interface MethodThisType {
-    /** Access inside a method invocation. Boolean value, true if this invocation is a stub. */
-    isSimulation: boolean;
-    /** The id of the user that made this method call, or `null` if no user was logged in. */
-    userId: string | null;
-    /**
-     * Access inside a method invocation. The connection that this method was received on. `null` if the method is not associated with a connection, eg. a server initiated method call. Calls
-     * to methods made from a server method which was in turn initiated from the client share the same `connection`. */
-    connection: Connection | null;
-    /**
-     * Set the logged in user.
-     * @param userId The value that should be returned by `userId` on this connection.
-     */
-    setUserId(userId: string | null): void;
-    /** Call inside a method invocation. Allow subsequent method from this client to begin running in a new fiber. */
-    unblock(): void;
-  }
-
-  /**
-   * Defines functions that can be invoked over the network by clients.
-   * @param methods Dictionary whose keys are method names and values are functions.
-   */
-  function methods(methods: {
-    [key: string]: (this: MethodThisType, ...args: any[]) => any;
-  }): void;
-
-  /**
-   * Invokes a method passing any number of arguments.
-   * @param name Name of method to invoke
-   * @param args Optional method arguments
-   */
-  function call(name: string, ...args: any[]): any;
-
-  function apply<
-    Result extends
-      | EJSONable
-      | EJSONable[]
-      | EJSONableProperty
-      | EJSONableProperty[]
-  >(
-    name: string,
-    args: ReadonlyArray<EJSONable | EJSONableProperty>,
-    options?: {
-      wait?: boolean | undefined;
-      onResultReceived?:
-        | ((
-            error: global_Error | Meteor.Error | undefined,
-            result?: Result
-          ) => void)
-        | undefined;
-      /**
-       * (Client only) if true, don't send this method again on reload, simply call the callback an error with the error code 'invocation-failed'.
-       */
-      noRetry?: boolean | undefined;
-      returnStubValue?: boolean | undefined;
-      throwStubExceptions?: boolean | undefined;
-    },
-    asyncCallback?: (
-      error: global_Error | Meteor.Error | undefined,
-      result?: Result
-    ) => void
-  ): any;
-  /** Method **/
 
   /** Url **/
   /**
@@ -364,37 +287,6 @@ export namespace Meteor {
     callback?: (error?: global_Error | Meteor.Error | Meteor.TypedError) => void
   ): void;
   /** Login **/
-
-  /** Event **/
-  interface Event {
-    type: string;
-    target: HTMLElement;
-    currentTarget: HTMLElement;
-    which: number;
-    stopPropagation(): void;
-    stopImmediatePropagation(): void;
-    preventDefault(): void;
-    isPropagationStopped(): boolean;
-    isImmediatePropagationStopped(): boolean;
-    isDefaultPrevented(): boolean;
-  }
-  interface EventHandlerFunction extends Function {
-    (event?: Meteor.Event, templateInstance?: Blaze.TemplateInstance): void;
-  }
-  interface EventMap {
-    [id: string]: Meteor.EventHandlerFunction;
-  }
-  /** Event **/
-
-  /** Connection **/
-  function reconnect(): void;
-
-  function disconnect(): void;
-  /** Connection **/
-
-  /** Status **/
-  function status(): DDP.DDPStatus;
-  /** Status **/
 
   /** Pub/Sub **/
   /**

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.10.2-2'
+  version: '1.10.3-qualia.1'
 });
 
 Package.registerBuildPlugin({

--- a/packages/meteor/package.js
+++ b/packages/meteor/package.js
@@ -2,7 +2,7 @@
 
 Package.describe({
   summary: "Core Meteor environment",
-  version: '1.10.3-qualia.1'
+  version: '1.10.3'
 });
 
 Package.registerBuildPlugin({

--- a/packages/promise/package.js
+++ b/packages/promise/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "promise",
-  version: "0.12.1-2",
+  version: "0.12.2",
   summary: "ECMAScript 2015 Promise polyfill with Fiber support",
   git: "https://github.com/meteor/promise",
   documentation: "README.md"

--- a/packages/shell-server/package.js
+++ b/packages/shell-server/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "shell-server",
-  version: "0.5.0-1",
+  version: "0.5.1",
   summary: "Server-side component of the `meteor shell` command.",
   documentation: "README.md"
 });


### PR DESCRIPTION
Work in progress - i'm nervous of making the change I'd need to make (converting d.ts files to use `@meteor/*` imports) 

meteor.d.ts imports blaze, mongo, ejson and ddp :| each of which imports meteor, causing a nice little circular dependency, but also - it's defining things on it's namespace that don't actually exist on the namespace - only when you've imported each of those (mongo => accounts-base) do those things actually become available.